### PR TITLE
Fix API base URL detection for production deployments

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,9 +1,19 @@
 // API Configuration
+//
+// We support three scenarios for determining the backend base URL:
+// 1. When a `REACT_APP_API_BASE_URL` environment variable is provided we use it.
+//    This lets deployments (including Vercel preview/production builds) control
+//    the API endpoint without requiring a code change.
+// 2. During local development we continue to default to the Express server
+//    running on port 3001.
+// 3. In hosted environments where the frontend and backend are deployed
+//    together (for example the production build served by Vercel) we fall
+//    back to relative `/api` paths so the browser uses the same origin.
+const BASE_URL = process.env.REACT_APP_API_BASE_URL
+  || (process.env.NODE_ENV === 'development' ? 'http://localhost:3001' : '');
+
 const API_CONFIG = {
-  // Automatically detect environment and use appropriate backend URL
-  BASE_URL: process.env.NODE_ENV === 'development' 
-    ? 'http://localhost:3001'  // Local development
-    : 'https://bmw-backend-g3lg5epgu-chris-projects-92828244.vercel.app', // Production
+  BASE_URL,
   
   // API endpoints
   ENDPOINTS: {


### PR DESCRIPTION
## Summary
- allow deployments to provide REACT_APP_API_BASE_URL and default to local server in development
- fall back to same-origin /api paths in production builds to avoid cross-origin fetch failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e19caaa08322b2412354076a8080